### PR TITLE
Remove Travis build status from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Apache Fineract CN MariaDB [![Build Status](https://api.travis-ci.com/apache/fineract-cn-mariadb.svg?branch=develop)](https://travis-ci.com/apache/fineract-cn-mariadb)
+# Apache Fineract CN MariaDB
 
 ## Abstract
 Apache Fineract CN is an application framework for digital financial services, a system to support nationwide and cross-national financial transactions and help to level and speed the creation of an inclusive, interconnected digital economy for every nation in the world.


### PR DESCRIPTION
Due to the removal of the Travis build scripts from the project. The build status in the README.md is now misleading and needs to be removed.